### PR TITLE
Add Flask API server and mobile web interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+node_modules/

--- a/README.md
+++ b/README.md
@@ -115,3 +115,19 @@ Give a ⭐️ if this project helped you!
 
 Copyright © 2019 [Radzi Ramli](https://github.com/wadzee).<br />
 This project is [MIT](https://github.com/wadzee/automated-hydroponics/blob/master/LICENSE) licensed.
+
+## Python Utilities and API
+
+This repository now includes a `sensor_monitor.py` script for reading serial data from Arduino sensors and posting them to an API. The accompanying `api_server.py` provides a simple REST interface for storing readings in memory.
+
+### Running the API Server
+
+```sh
+pip install flask
+python api_server.py
+```
+
+### Mobile Web Interface
+
+The `mobile/` directory contains a basic mobile-friendly page that fetches the latest sensor values. Run the API server and open `mobile/index.html` in your browser.
+

--- a/api_server.py
+++ b/api_server.py
@@ -1,0 +1,50 @@
+import json
+from datetime import datetime
+from typing import List, Dict
+
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+# In-memory store for sensor readings
+readings: List[Dict[str, str]] = []
+
+
+@app.route('/api/readings', methods=['POST'])
+def add_reading():
+    """Add a new sensor reading.
+
+    Expected JSON payload::
+        {
+            "light": <int>,
+            "ph": <float>,
+            "ec": <float>
+        }
+    """
+    data = request.get_json(force=True)
+    reading = {
+        'timestamp': datetime.utcnow().isoformat() + 'Z',
+        'light': data.get('light'),
+        'ph': data.get('ph'),
+        'ec': data.get('ec'),
+    }
+    readings.append(reading)
+    return jsonify(reading), 201
+
+
+@app.route('/api/readings', methods=['GET'])
+def list_readings():
+    """Return all sensor readings in chronological order."""
+    return jsonify(readings)
+
+
+@app.route('/api/readings/latest', methods=['GET'])
+def latest_reading():
+    """Return the most recent sensor reading."""
+    if not readings:
+        return jsonify({'error': 'no readings yet'}), 404
+    return jsonify(readings[-1])
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/mobile/app.js
+++ b/mobile/app.js
@@ -1,0 +1,18 @@
+async function fetchLatest() {
+  try {
+    const res = await fetch('/api/readings/latest');
+    if (!res.ok) {
+      document.getElementById('reading').innerText = 'No data';
+      return;
+    }
+    const data = await res.json();
+    document.getElementById('reading').innerText =
+      `Işık: ${data.light}, pH: ${data.ph}, EC: ${data.ec}, Zaman: ${data.timestamp}`;
+  } catch (err) {
+    document.getElementById('reading').innerText = 'Hata: ' + err;
+  }
+}
+
+document.getElementById('refresh').addEventListener('click', fetchLatest);
+
+fetchLatest();

--- a/mobile/index.html
+++ b/mobile/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hydroponic Monitor</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+</head>
+<body class="p-3">
+  <h1 class="mb-4">Hydroponic Sensors</h1>
+  <div id="reading" class="mb-3">No data</div>
+  <button id="refresh" class="btn btn-primary">Refresh</button>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/sensor_monitor.py
+++ b/sensor_monitor.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Read hydroponic sensor data from a serial port and optionally POST to a remote server.
+
+This script expects the Arduino sketch to print space-separated values in the
+order: N light_value ph_value ec_value. It will parse the data, display it on
+stdout and, if an HTTP endpoint is provided, send the measurements as JSON.
+"""
+import argparse
+import json
+import sys
+import time
+from typing import Optional
+
+try:
+    import serial  # type: ignore
+except Exception:  # pragma: no cover
+    serial = None  # pyserial may not be installed on this system
+
+try:
+    import requests  # type: ignore
+except Exception:  # pragma: no cover
+    requests = None
+
+
+def read_loop(port: str, baud: int, endpoint: Optional[str]) -> None:
+    if serial is None:
+        raise RuntimeError("pyserial is required to read from the serial port")
+
+    with serial.Serial(port, baudrate=baud, timeout=1) as ser:
+        while True:
+            line = ser.readline().decode().strip()
+            if not line:
+                continue
+            parts = line.split()
+            if len(parts) < 4:
+                continue
+            _, light, ph, ec = parts[:4]
+            data = {"light": float(light), "ph": float(ph), "ec": float(ec)}
+            print(json.dumps(data))
+            if endpoint and requests is not None:
+                try:
+                    requests.post(endpoint, json=data, timeout=5)
+                except Exception as exc:  # pragma: no cover
+                    print(f"Failed to post data: {exc}", file=sys.stderr)
+            time.sleep(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Monitor hydroponic sensor data")
+    parser.add_argument("--port", default="/dev/ttyUSB0", help="Serial port path")
+    parser.add_argument("--baud", type=int, default=9600, help="Serial baud rate")
+    parser.add_argument(
+        "--endpoint",
+        help="HTTP endpoint to post JSON data (optional)",
+    )
+    args = parser.parse_args()
+    try:
+        read_loop(args.port, args.baud, args.endpoint)
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- provide Flask-based REST API for storing sensor readings
- add simple mobile-friendly web page that fetches latest sensor values
- document Python utilities and API usage in README

## Testing
- `python -m py_compile sensor_monitor.py api_server.py`
- `python api_server.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install flask` *(fails: Could not find a version that satisfies the requirement)*


------
https://chatgpt.com/codex/tasks/task_e_68ad9d5953e08333875b6d517aad7b0e