### PR TITLE
Add optional auto-refresh toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,5 +26,16 @@ async function fetchLatest() {
 }
 
 document.getElementById('refresh').addEventListener('click', fetchLatest);
-setInterval(fetchLatest, 5000);
-fetchLatest();
+
+const autoBox = document.getElementById('auto-refresh');
+let autoTimer = null;
+
+autoBox.addEventListener('change', () => {
+  if (autoBox.checked) {
+    fetchLatest();
+    autoTimer = setInterval(fetchLatest, 5000);
+  } else {
+    clearInterval(autoTimer);
+    autoTimer = null;
+  }
+});

--- a/index.html
+++ b/index.html
@@ -41,6 +41,10 @@
 
     <p>Son güncelleme: <span id="timestamp">-</span></p>
     <button id="refresh" class="btn btn-primary">Yenile</button>
+    <div class="form-check form-check-inline ms-2">
+      <input class="form-check-input" type="checkbox" id="auto-refresh">
+      <label class="form-check-label" for="auto-refresh">Otomatik</label>
+    </div>
   </div>
 
   <script src="app.js"></script>


### PR DESCRIPTION
## Summary
- Add checkbox for enabling automatic API refresh
- Implement auto-refresh logic in JS when checkbox is enabled

## Testing
- `node --check app.js && echo "syntax ok"`
- `python -m py_compile api_server.py sensor_monitor.py && echo "py ok"`


------
https://chatgpt.com/codex/tasks/task_e_68adb18fb964833383ba90071432529f